### PR TITLE
Update to elm 0.18.0

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -8,8 +8,8 @@
     ],
     "exposed-modules": ["TypedFormat"],
     "dependencies": {
-        "elm-lang/core": "4.0.5 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0"
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.1 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -9,8 +9,8 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.5 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0"
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.1 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/TypedFormat.elm
+++ b/src/TypedFormat.elm
@@ -196,13 +196,13 @@ currency symbol abbreviateUnits isAccounting sep decimalPoint =
         toCurrencyStr x =
             if abbreviateUnits then
                 let
-                    ( x', b ) =
+                    ( y, b ) =
                         numberWithBase x
 
                     suffix =
                         Dict.get b currencySuffix
                 in
-                    prettyFloatHelper (Just symbol) suffix isAccounting ',' '.' 2 x'
+                    prettyFloatHelper (Just symbol) suffix isAccounting ',' '.' 2 y
             else
                 prettyFloatHelper (Just symbol) Nothing isAccounting ',' '.' 2 x
     in


### PR DESCRIPTION
I am using this library for a personal project and needed to make adjustments to some version numbers. Also needed to change  x' to y since that feature is deprecated in 0.18.0.